### PR TITLE
Apply framework name changes (CB-Ladybug -> CB-MCKS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
-# GitHub Pages to host CB-Ladybug API Documentation
+# GitHub Pages to host CB-MCKS API Documentation
 
-CB-Ladybug is a Framework for Cloud-Barista Platform to Manage Multi-Cloud Application Service.
-(https://github.com/cloud-barista/cb-ladybug)
+CB-MCKS is a Framework for Cloud-Barista Platform to Manage Multi-Cloud Kubernetes Service.
+(https://github.com/cloud-barista/cb-mcks)
 
-This repository is to host CB-Ladybug API Documentation in GitHub Pages.
+This repository is to host CB-MCKS API Documentation in GitHub Pages.
 
 ```
 [NOTE]
-CB-Ladybug is currently under development. (the latest version is 0.3 espresso)
+CB-MCKS is currently under development. (the latest version is 0.4 Cafe Mocha)
 So, we do not recommend using the current release in production.
-Please note that the functionalities of CB-Ladybug are not stable and secure yet.
-If you have any difficulties in using CB-Ladybug, please let us know.
+Please note that the functionalities of CB-MCKS are not stable and secure yet.
+If you have any difficulties in using CB-MCKS, please let us know.
 (Open an issue or Join the cloud-barista Slack)
 ```
 
-The API document in this repo is for CB-ladybug master branch. 
-(https://github.com/cloud-barista/cb-ladybug/tree/master)
+The API document in this repo is for CB-MCKS master branch. 
+(https://github.com/cloud-barista/cb-mcks/tree/master)
 
 It is not for API release but for development.
 (master branch is a dev branch)
 
 ## Access the API documentation page
 
-Access to: https://cloud-barista.github.io/cb-ladybug-api-web/
+Access to: https://cloud-barista.github.io/cb-mcks-api-web/
 (Authorize with `default`/`default`)
 
 ## How to update the API documentation page
 
 Replace 
 
-https://github.com/cloud-barista/cb-ladybug-api-web/blob/master/swagger.yaml 
+https://github.com/cloud-barista/cb-mcks-api-web/blob/master/swagger.yaml 
 
 with 
 
-https://github.com/cloud-barista/cb-ladybug/blob/master/src/docs/swagger.yaml
+https://github.com/cloud-barista/cb-mcks/blob/master/src/docs/swagger.yaml
 
 GitHub pages will update the page automatically.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,8 +1,16 @@
-basePath: /ladybug
+basePath: /mcks
 definitions:
+  app.Status:
+    properties:
+      message:
+        example: Any message
+        type: string
+    type: object
   model.Cluster:
     properties:
       clusterConfig:
+        type: string
+      cpLeader:
         type: string
       kind:
         type: string
@@ -12,13 +20,21 @@ definitions:
         type: string
       namespace:
         type: string
+      networkCni:
+        enum:
+        - kilo
+        - canal
+        type: string
       nodes:
         items:
           $ref: '#/definitions/model.Node'
         type: array
       status:
-        type: string
-      uid:
+        enum:
+        - created
+        - provisioning
+        - completed
+        - failed
         type: string
     type: object
   model.ClusterList:
@@ -32,20 +48,55 @@ definitions:
     type: object
   model.ClusterReq:
     properties:
-      controlPlaneNodeCount:
-        type: integer
-      controlPlaneNodeSpec:
-        type: string
+      config:
+        $ref: '#/definitions/model.Config'
+        type: object
+      controlPlane:
+        items:
+          $ref: '#/definitions/model.NodeConfig'
+        type: array
       name:
+        example: cluster-01
         type: string
-      workerNodeCount:
-        type: integer
-      workerNodeSpec:
+      worker:
+        items:
+          $ref: '#/definitions/model.NodeConfig'
+        type: array
+    type: object
+  model.Config:
+    properties:
+      kubernetes:
+        $ref: '#/definitions/model.Kubernetes'
+        type: object
+    type: object
+  model.Kubernetes:
+    properties:
+      networkCni:
+        enum:
+        - kilo
+        - canal
+        example: kilo
+        type: string
+      podCidr:
+        example: 10.244.0.0/16
+        type: string
+      serviceCidr:
+        example: 10.96.0.0/12
+        type: string
+      serviceDnsDomain:
+        example: cluster.local
         type: string
     type: object
   model.Node:
     properties:
       credential:
+        type: string
+      csp:
+        enum:
+        - aws
+        - gcp
+        - azure
+        - alibaba
         type: string
       kind:
         type: string
@@ -54,10 +105,23 @@ definitions:
       publicIp:
         type: string
       role:
+        enum:
+        - control-plane
+        - worker
         type: string
       spec:
         type: string
-      uid:
+    type: object
+  model.NodeConfig:
+    properties:
+      connection:
+        example: config-aws-ap-northeast-2
+        type: string
+      count:
+        example: 3
+        type: integer
+      spec:
+        example: t2.medium
         type: string
     type: object
   model.NodeList:
@@ -71,12 +135,14 @@ definitions:
     type: object
   model.NodeReq:
     properties:
-      config:
-        type: string
-      workerNodeCount:
-        type: integer
-      workerNodeSpec:
-        type: string
+      controlPlane:
+        items:
+          $ref: '#/definitions/model.NodeConfig'
+        type: array
+      worker:
+        items:
+          $ref: '#/definitions/model.NodeConfig'
+        type: array
     type: object
   model.Status:
     properties:
@@ -93,13 +159,12 @@ info:
     email: contact-to-cloud-barista@googlegroups.com
     name: API Support
     url: http://cloud-barista.github.io
-  description: CB-Ladybug REST API
+  description: CB-MCKS REST API
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  termsOfService: http://swagger.io/terms/
-  title: CB-Ladybug REST API
-  version: 0.3.0-espresso
+  title: CB-MCKS REST API
+  version: latest
 paths:
   /healthy:
     get:
@@ -121,10 +186,10 @@ paths:
     get:
       consumes:
       - application/json
-      description: List Cluster
+      description: List all Clusters
       operationId: ListCluster
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
@@ -136,7 +201,11 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.ClusterList'
-      summary: List Cluster
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+      summary: List all Clusters
       tags:
       - Cluster
     post:
@@ -145,14 +214,14 @@ paths:
       description: Create Cluster
       operationId: CreateCluster
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
         type: string
-      - description: Reuest json
+      - description: Request Body to create cluster
         in: body
-        name: json
+        name: ClusterReq
         required: true
         schema:
           $ref: '#/definitions/model.ClusterReq'
@@ -163,6 +232,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.Cluster'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.Status'
       summary: Create Cluster
       tags:
       - Cluster
@@ -170,15 +247,15 @@ paths:
     delete:
       consumes:
       - application/json
-      description: Delete a cluster
+      description: Delete Cluster
       operationId: DeleteCluster
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
         type: string
-      - description: cluster
+      - description: Cluster Name
         in: path
         name: cluster
         required: true
@@ -190,7 +267,15 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.Status'
-      summary: Delete a cluster
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.Status'
+      summary: Delete Cluster
       tags:
       - Cluster
     get:
@@ -199,12 +284,12 @@ paths:
       description: Get Cluster
       operationId: GetCluster
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
         type: string
-      - description: cluster
+      - description: Cluster Name
         in: path
         name: cluster
         required: true
@@ -216,6 +301,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.Cluster'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/app.Status'
       summary: Get Cluster
       tags:
       - Cluster
@@ -223,15 +316,15 @@ paths:
     get:
       consumes:
       - application/json
-      description: List Node
+      description: List all Nodes in specified Cluster
       operationId: ListNode
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
         type: string
-      - description: cluster
+      - description: Cluster Name
         in: path
         name: cluster
         required: true
@@ -243,28 +336,32 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.NodeList'
-      summary: List Node
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+      summary: List all Nodes in specified Cluster
       tags:
       - Node
     post:
       consumes:
       - application/json
-      description: Add Node
+      description: Add Node in specified Cluster
       operationId: AddNode
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
         type: string
-      - description: cluster
+      - description: Cluster Name
         in: path
         name: cluster
         required: true
         type: string
-      - description: Reuest json
+      - description: Request Body to add node
         in: body
-        name: json
+        name: nodeReq
         required: true
         schema:
           $ref: '#/definitions/model.NodeReq'
@@ -275,27 +372,35 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.Node'
-      summary: Add Node
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.Status'
+      summary: Add Node in specified Cluster
       tags:
       - Node
   /ns/{namespace}/clusters/{cluster}/nodes/{node}:
     delete:
       consumes:
       - application/json
-      description: Remove Node
+      description: Remove Node in specified Cluster
       operationId: RemoveNode
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
         type: string
-      - description: cluster
+      - description: Cluster Name
         in: path
         name: cluster
         required: true
         type: string
-      - description: node
+      - description: Node Name
         in: path
         name: node
         required: true
@@ -307,26 +412,34 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.Status'
-      summary: Remove Node
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.Status'
+      summary: Remove Node in specified Cluster
       tags:
       - Node
     get:
       consumes:
       - application/json
-      description: Get Node
+      description: Get Node in specified Cluster
       operationId: GetNode
       parameters:
-      - description: namespace
+      - description: Namespace ID
         in: path
         name: namespace
         required: true
         type: string
-      - description: cluster
+      - description: Cluster Name
         in: path
         name: cluster
         required: true
         type: string
-      - description: node
+      - description: Node Name
         in: path
         name: node
         required: true
@@ -338,7 +451,18 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/model.Node'
-      summary: Get Node
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.Status'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/app.Status'
+      summary: Get Node in specified Cluster
       tags:
       - Node
+securityDefinitions:
+  BasicAuth:
+    type: basic
 swagger: "2.0"


### PR DESCRIPTION
CC: @itnpeople @vlatte

- Apply framework name changes (CB-Ladybug -> CB-MCKS)
- 이 repo에 있는 `swagger.yaml` 파일을 최신(2021-09-06)으로 업데이트
  (https://github.com/cloud-barista/cb-mcks/blob/master/src/docs/swagger.yaml)

[For anyone's information]
CB-MCKS repo의 최신 Swagger doc (https://github.com/cloud-barista/cb-mcks/blob/master/src/docs/swagger.yaml) 의 내용을 표시해 주는
Swagger doc 접속 주소:
https://cloud-barista.github.io/cb-mcks-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-mcks/master/src/docs/swagger.yaml

CB-MCKS repo의 특정 버전 YAML 파일의 내용을 표시해 주는
Swagger doc 접속 주소:
https://cloud-barista.github.io/cb-mcks-api-web/?url=https://raw.githubusercontent.com/cloud-barista/cb-mcks/master/src/docs/v0.4.0.yaml
