### PR TITLE
refactor: revert to CB-Ladybug API Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
-# GitHub Pages to host CB-MCKS API Documentation
+# GitHub Pages to host CB-Ladybug API Documentation
 
-CB-MCKS is a Framework for Cloud-Barista Platform to Manage Multi-Cloud Kubernetes Service.
-(https://github.com/cloud-barista/cb-mcks)
+CB-Ladybug is a framework to manage multi-cloud application runtimes in Cloud-Barista platform.
+(https://github.com/cloud-barista/cb-ladybug)
 
-This repository is to host CB-MCKS API Documentation in GitHub Pages.
+This repository is to host CB-Ladybug API Documentation in GitHub Pages.
 
 ```
 [NOTE]
-CB-MCKS is currently under development. (the latest version is 0.4 Cafe Mocha)
+CB-Ladybug is currently under development. (the latest version is 0.7.0 (Cortado))
 So, we do not recommend using the current release in production.
-Please note that the functionalities of CB-MCKS are not stable and secure yet.
-If you have any difficulties in using CB-MCKS, please let us know.
+Please note that the functionalities of CB-Ladybug are not stable and secure yet.
+If you have any difficulties in using CB-Ladybug, please let us know.
 (Open an issue or Join the cloud-barista Slack)
 ```
 
-The API document in this repo is for CB-MCKS master branch. 
-(https://github.com/cloud-barista/cb-mcks/tree/master)
+The API document in this repo is for CB-Ladybug master branch.
+(https://github.com/cloud-barista/cb-ladybug/tree/master)
 
 It is not for API release but for development.
 (master branch is a dev branch)
 
 ## Access the API documentation page
 
-Access to: https://cloud-barista.github.io/cb-mcks-api-web/
+Access to: https://cloud-barista.github.io/cb-ladybug-api-web/
 (Authorize with `default`/`default`)
 
 ## How to update the API documentation page
 
 Replace 
 
-https://github.com/cloud-barista/cb-mcks-api-web/blob/master/swagger.yaml 
+https://github.com/cloud-barista/cb-ladybug-api-web/blob/master/swagger.yaml
 
 with 
 
-https://github.com/cloud-barista/cb-mcks/blob/master/src/docs/swagger.yaml
+https://github.com/cloud-barista/cb-ladybug/blob/master/src/docs/swagger.yaml
 
 GitHub pages will update the page automatically.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /mcks
+basePath: /ladybug
 definitions:
   app.Status:
     properties:
@@ -159,11 +159,11 @@ info:
     email: contact-to-cloud-barista@googlegroups.com
     name: API Support
     url: http://cloud-barista.github.io
-  description: CB-MCKS REST API
+  description: CB-Ladybug REST API
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  title: CB-MCKS REST API
+  title: CB-Ladybug REST API
   version: latest
 paths:
   /healthy:


### PR DESCRIPTION
CB-Ladybug의 범위 변경에 따라 MCKS 저장소와 통합하기로 함에 따라 이름 변경